### PR TITLE
Add ARCH_X64 to ARCH_ALL and add endian check support

### DIFF
--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -51,6 +51,7 @@ module Arch
     [
       ARCH_X86,
       ARCH_X86_64,
+      ARCH_X64,
       ARCH_MIPS,
       ARCH_MIPSLE,
       ARCH_MIPSBE,
@@ -147,6 +148,8 @@ module Arch
       when ARCH_X86
         return ENDIAN_LITTLE
       when ARCH_X86_64
+        return ENDIAN_LITTLE
+      when ARCH_X64
         return ENDIAN_LITTLE
       when ARCH_MIPS # ambiguous
         return ENDIAN_BIG


### PR DESCRIPTION
While refactoring `ARCH_X86_64` use in MSF it was found that the `ARCH_X64` type was not included in `ARCH_ALL` and didn't have an entry in the endian check. This PR fixes both of these issues, and means that we can move forward to moving all payloads/modules over to `ARCH_X64` with the aim of avoiding the use of `ARCH_X86_64` altogether.
