### PR TITLE
Add new arches for mettle

### DIFF
--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -24,63 +24,35 @@ module Arch
   # Architecture constants
   #
   ARCH_ANY     = '_any_'
-  ARCH_X86     = 'x86'
-  ARCH_X86_64  = 'x86_64'
-  ARCH_X64     = 'x64' # To be used for compatability with ARCH_X86_64
-  ARCH_MIPS    = 'mips'
-  ARCH_MIPSLE  = 'mipsle'
-  ARCH_MIPSBE  = 'mipsbe'
-  ARCH_MIPS64  = 'mips64'
-  ARCH_PPC     = 'ppc'
-  ARCH_PPC64   = 'ppc64'
-  ARCH_PPC64LE = 'ppc64le'
-  ARCH_CBEA    = 'cbea'
-  ARCH_CBEA64  = 'cbea64'
-  ARCH_SPARC   = 'sparc'
-  ARCH_CMD     = 'cmd'
-  ARCH_PHP     = 'php'
-  ARCH_TTY     = 'tty'
-  ARCH_ARMLE   = 'armle'
-  ARCH_ARMBE   = 'armbe'
-  ARCH_AARCH64 = 'aarch64'
-  ARCH_JAVA    = 'java'
-  ARCH_RUBY    = 'ruby'
-  ARCH_DALVIK  = 'dalvik'
-  ARCH_PYTHON  = 'python'
-  ARCH_NODEJS  = 'nodejs'
-  ARCH_FIREFOX = 'firefox'
-  ARCH_ZARCH   = 'zarch'
-  ARCH_TYPES   =
+  ARCH_ALL = ARCH_TYPES   =
     [
-      ARCH_X86,
-      ARCH_X86_64,
-      ARCH_X64,
-      ARCH_MIPS,
-      ARCH_MIPSLE,
-      ARCH_MIPSBE,
-      ARCH_MIPS64,
-      ARCH_PPC,
-      ARCH_PPC64,
-      ARCH_PPC64LE,
-      ARCH_CBEA,
-      ARCH_CBEA64,
-      ARCH_SPARC,
-      ARCH_ARMLE,
-      ARCH_ARMBE,
-      ARCH_AARCH64,
-      ARCH_CMD,
-      ARCH_PHP,
-      ARCH_TTY,
-      ARCH_JAVA,
-      ARCH_RUBY,
-      ARCH_DALVIK,
-      ARCH_PYTHON,
-      ARCH_NODEJS,
-      ARCH_FIREFOX,
-      ARCH_ZARCH,
+      ARCH_X86     = 'x86',
+      ARCH_X86_64  = 'x86_64',
+      ARCH_X64     = 'x64', # To be used for compatability with ARCH_X86_64
+      ARCH_MIPS    = 'mips',
+      ARCH_MIPSLE  = 'mipsle',
+      ARCH_MIPSBE  = 'mipsbe',
+      ARCH_MIPS64  = 'mips64',
+      ARCH_PPC     = 'ppc',
+      ARCH_PPC64   = 'ppc64',
+      ARCH_PPC64LE = 'ppc64le',
+      ARCH_CBEA    = 'cbea',
+      ARCH_CBEA64  = 'cbea64',
+      ARCH_SPARC   = 'sparc',
+      ARCH_ARMLE   = 'armle',
+      ARCH_ARMBE   = 'armbe',
+      ARCH_AARCH64 = 'aarch64',
+      ARCH_CMD     = 'cmd',
+      ARCH_PHP     = 'php',
+      ARCH_TTY     = 'tty',
+      ARCH_JAVA    = 'java',
+      ARCH_RUBY    = 'ruby',
+      ARCH_DALVIK  = 'dalvik',
+      ARCH_PYTHON  = 'python',
+      ARCH_NODEJS  = 'nodejs',
+      ARCH_FIREFOX = 'firefox',
+      ARCH_ZARCH   = 'zarch',
     ]
-
-  ARCH_ALL = ARCH_TYPES
 
   #
   # Endian constants

--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -30,8 +30,10 @@ module Arch
   ARCH_MIPS    = 'mips'
   ARCH_MIPSLE  = 'mipsle'
   ARCH_MIPSBE  = 'mipsbe'
+  ARCH_MIPS64  = 'mips64'
   ARCH_PPC     = 'ppc'
   ARCH_PPC64   = 'ppc64'
+  ARCH_PPC64LE = 'ppc64le'
   ARCH_CBEA    = 'cbea'
   ARCH_CBEA64  = 'cbea64'
   ARCH_SPARC   = 'sparc'
@@ -40,6 +42,7 @@ module Arch
   ARCH_TTY     = 'tty'
   ARCH_ARMLE   = 'armle'
   ARCH_ARMBE   = 'armbe'
+  ARCH_AARCH64 = 'aarch64'
   ARCH_JAVA    = 'java'
   ARCH_RUBY    = 'ruby'
   ARCH_DALVIK  = 'dalvik'
@@ -55,13 +58,16 @@ module Arch
       ARCH_MIPS,
       ARCH_MIPSLE,
       ARCH_MIPSBE,
+      ARCH_MIPS64,
       ARCH_PPC,
       ARCH_PPC64,
+      ARCH_PPC64LE,
       ARCH_CBEA,
       ARCH_CBEA64,
       ARCH_SPARC,
       ARCH_ARMLE,
       ARCH_ARMBE,
+      ARCH_AARCH64,
       ARCH_CMD,
       ARCH_PHP,
       ARCH_TTY,
@@ -122,14 +128,20 @@ module Arch
         [addr].pack('N')
       when ARCH_MIPSLE
         [addr].pack('V')
+      when ARCH_MIPS64
+        [addr].pack('Q>')
       when ARCH_PPC  # ambiguous
         [addr].pack('N')
+      when ARCH_PPC64LE
+        [addr].pack('Q<')
       when ARCH_SPARC
         [addr].pack('N')
       when ARCH_ARMLE
         [addr].pack('V')
       when ARCH_ARMBE
         [addr].pack('N')
+      when ARCH_AARCH64
+        [addr].pack('Q<')
       when ARCH_ZARCH
         [addr].pack('Q>')
     end
@@ -157,14 +169,20 @@ module Arch
         return ENDIAN_LITTLE
       when ARCH_MIPSBE
         return ENDIAN_BIG
+      when ARCH_MIPS64
+        return ENDIAN_BIG
       when ARCH_PPC  # ambiguous
         return ENDIAN_BIG
+      when ARCH_PPC64LE
+        return ENDIAN_LITTLE
       when ARCH_SPARC
         return ENDIAN_BIG
       when ARCH_ARMLE
         return ENDIAN_LITTLE
       when ARCH_ARMBE
         return ENDIAN_BIG
+      when ARCH_AARCH64
+        return ENDIAN_LITTLE
       when ARCH_ZARCH
         return ENDIAN_BIG
     end

--- a/spec/lib/rex/arch_spec.rb
+++ b/spec/lib/rex/arch_spec.rb
@@ -86,11 +86,27 @@ RSpec.describe Rex::Arch do
       end
     end
 
+    context "when arch is ARCH_MIPS64" do
+      let(:arch) { Rex::Arch::ARCH_MIPS64 }
+      let(:addr) { 0x4142434445464748 }
+      it "packs addr as 64-bit unsigned, big-endian" do
+        is_expected.to eq("ABCDEFGH")
+      end
+    end
+
     context "when arch is ARCH_PPC" do
       let(:arch) { Rex::Arch::ARCH_PPC }
       let(:addr) { 0x41424344 }
       it "packs addr as 32-bit unsigned, big-endian" do
         is_expected.to eq("ABCD")
+      end
+    end
+
+    context "when arch is ARCH_PPC64LE" do
+      let(:arch) { Rex::Arch::ARCH_PPC64LE }
+      let(:addr) { 0x4142434445464748 }
+      it "packs addr as 64-bit unsigned, little-endian" do
+        is_expected.to eq("HGFEDCBA")
       end
     end
 
@@ -115,6 +131,14 @@ RSpec.describe Rex::Arch do
       let(:addr) { 0x41424344 }
       it "packs addr as 32-bit unsigned, big-endian" do
         is_expected.to eq("ABCD")
+      end
+    end
+
+    context "when arch is ARCH_AARCH64" do
+      let(:arch) { Rex::Arch::ARCH_AARCH64 }
+      let(:addr) { 0x4142434445464748 }
+      it "packs addr as 64-bit unsigned, little-endian" do
+        is_expected.to eq("HGFEDCBA")
       end
     end
 
@@ -145,10 +169,13 @@ RSpec.describe Rex::Arch do
         Rex::Arch::ARCH_MIPS => Rex::Arch::ENDIAN_BIG,
         Rex::Arch::ARCH_MIPSLE => Rex::Arch::ENDIAN_LITTLE,
         Rex::Arch::ARCH_MIPSBE => Rex::Arch::ENDIAN_BIG,
+        Rex::Arch::ARCH_MIPS64 => Rex::Arch::ENDIAN_BIG,
         Rex::Arch::ARCH_PPC => Rex::Arch::ENDIAN_BIG,
+        Rex::Arch::ARCH_PPC64LE => Rex::Arch::ENDIAN_LITTLE,
         Rex::Arch::ARCH_SPARC => Rex::Arch::ENDIAN_BIG,
         Rex::Arch::ARCH_ARMLE => Rex::Arch::ENDIAN_LITTLE,
-        Rex::Arch::ARCH_ARMBE => Rex::Arch::ENDIAN_BIG
+        Rex::Arch::ARCH_ARMBE => Rex::Arch::ENDIAN_BIG,
+        Rex::Arch::ARCH_AARCH64 => Rex::Arch::ENDIAN_LITTLE
       }
     end
     subject { described_class.endian(arch) }


### PR DESCRIPTION
This adds three new 64-bit arches capable of running *nix systems.

Verification
========
- [x] Specs should pass
- [x] Framework specs should pass when pointed to this branch