### PR TITLE
add additional architectures

### DIFF
--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -33,12 +33,14 @@ module Arch
       ARCH_MIPSLE  = 'mipsle',
       ARCH_MIPSBE  = 'mipsbe',
       ARCH_MIPS64  = 'mips64',
+      ARCH_MIPS64LE = 'mips64le',
       ARCH_PPC     = 'ppc',
       ARCH_PPC64   = 'ppc64',
       ARCH_PPC64LE = 'ppc64le',
       ARCH_CBEA    = 'cbea',
       ARCH_CBEA64  = 'cbea64',
       ARCH_SPARC   = 'sparc',
+      ARCH_SPARC64 = 'sparc64',
       ARCH_ARMLE   = 'armle',
       ARCH_ARMBE   = 'armbe',
       ARCH_AARCH64 = 'aarch64',
@@ -102,12 +104,16 @@ module Arch
         [addr].pack('V')
       when ARCH_MIPS64
         [addr].pack('Q>')
+      when ARCH_MIPS64LE
+        [addr].pack('Q<')
       when ARCH_PPC  # ambiguous
         [addr].pack('N')
       when ARCH_PPC64LE
         [addr].pack('Q<')
       when ARCH_SPARC
         [addr].pack('N')
+      when ARCH_SPARC64
+        [addr].pack('Q>')
       when ARCH_ARMLE
         [addr].pack('V')
       when ARCH_ARMBE
@@ -143,11 +149,15 @@ module Arch
         return ENDIAN_BIG
       when ARCH_MIPS64
         return ENDIAN_BIG
+      when ARCH_MIPS64LE
+        return ENDIAN_LITTLE
       when ARCH_PPC  # ambiguous
         return ENDIAN_BIG
       when ARCH_PPC64LE
         return ENDIAN_LITTLE
       when ARCH_SPARC
+        return ENDIAN_BIG
+      when ARCH_SPARC64
         return ENDIAN_BIG
       when ARCH_ARMLE
         return ENDIAN_LITTLE

--- a/spec/lib/rex/arch_spec.rb
+++ b/spec/lib/rex/arch_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe Rex::Arch do
       end
     end
 
+    context "when arch is ARCH_MIPS64LE" do
+      let(:arch) { Rex::Arch::ARCH_MIPS64LE }
+      let(:addr) { 0x4142434445464748 }
+      it "packs addr as 64-bit unsigned, little-endian" do
+        is_expected.to eq("HGFEDCBA")
+      end
+    end
+
     context "when arch is ARCH_PPC" do
       let(:arch) { Rex::Arch::ARCH_PPC }
       let(:addr) { 0x41424344 }
@@ -118,6 +126,14 @@ RSpec.describe Rex::Arch do
       end
     end
 
+    context "when arch is ARCH_SPARC64" do
+      let(:arch) { Rex::Arch::ARCH_SPARC64 }
+      let(:addr) { 0x4142434445464748 }
+      it "packs addr as 64-bit unsigned, big-endian" do
+        is_expected.to eq("ABCDEFGH")
+      end
+    end
+
     context "when arch is ARCH_ARMLE" do
       let(:arch) { Rex::Arch::ARCH_ARMLE }
       let(:addr) { 0x41424344 }
@@ -139,6 +155,14 @@ RSpec.describe Rex::Arch do
       let(:addr) { 0x4142434445464748 }
       it "packs addr as 64-bit unsigned, little-endian" do
         is_expected.to eq("HGFEDCBA")
+      end
+    end
+
+    context "when arch is ARCH_ZARCH" do
+      let(:arch) { Rex::Arch::ARCH_ZARCH }
+      let(:addr) { 0x4142434445464748 }
+      it "packs addr as 64-bit unsigned, big-endian" do
+        is_expected.to eq("ABCDEFGH")
       end
     end
 


### PR DESCRIPTION
This adds missing architectures from https://github.com/rapid7/metasploit-framework/pull/8467