### PR TITLE
Add SuperH Arch

### DIFF
--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -55,7 +55,9 @@ module Arch
       ARCH_NODEJS    = 'nodejs',
       ARCH_FIREFOX   = 'firefox',
       ARCH_ZARCH     = 'zarch',
-      ARCH_R         = 'r'
+      ARCH_R         = 'r',
+      ARCH_SHLE     = 'shle',
+      ARCH_SHBE     = 'shbe'
     ]
 
   #
@@ -126,6 +128,10 @@ module Arch
         [addr].pack('Q<')
       when ARCH_ZARCH
         [addr].pack('Q>')
+      when ARCH_SHLE
+        [addr].pack('V')
+      when ARCH_SHBE
+        [addr].pack('N')
     end
   end
 
@@ -172,6 +178,10 @@ module Arch
       when ARCH_AARCH64
         return ENDIAN_LITTLE
       when ARCH_ZARCH
+        return ENDIAN_BIG
+      when ARCH_SHLE
+        return ENDIAN_LITTLE
+      when ARCH_SHBE
         return ENDIAN_BIG
     end
 

--- a/spec/lib/rex/arch_spec.rb
+++ b/spec/lib/rex/arch_spec.rb
@@ -166,6 +166,22 @@ RSpec.describe Rex::Arch do
       end
     end
 
+    context "when arch is ARCH_SHLE" do
+      let(:arch) { Rex::Arch::ARCH_SHLE }
+      let(:addr) { 0x41424344 }
+      it "packs addr as 32-bit unsigned, little-endian" do
+        is_expected.to eq("DCBA")
+      end
+    end
+
+    context "when arch is ARCH_SHBE" do
+      let(:arch) { Rex::Arch::ARCH_SHBE }
+      let(:addr) { 0x41424344 }
+      it "packs addr as 32-bit unsigned, big-endian" do
+        is_expected.to eq("ABCD")
+      end
+    end
+
     context "when arch is invalid" do
       let(:arch) { Rex::Arch::ARCH_FIREFOX }
       let(:addr) { 0x41424344 }
@@ -199,7 +215,9 @@ RSpec.describe Rex::Arch do
         Rex::Arch::ARCH_SPARC => Rex::Arch::ENDIAN_BIG,
         Rex::Arch::ARCH_ARMLE => Rex::Arch::ENDIAN_LITTLE,
         Rex::Arch::ARCH_ARMBE => Rex::Arch::ENDIAN_BIG,
-        Rex::Arch::ARCH_AARCH64 => Rex::Arch::ENDIAN_LITTLE
+        Rex::Arch::ARCH_AARCH64 => Rex::Arch::ENDIAN_LITTLE,
+        Rex::Arch::ARCH_SHLE => Rex::Arch::ENDIAN_LITTLE,
+        Rex::Arch::ARCH_SHBE => Rex::Arch::ENDIAN_BIG
       }
     end
     subject { described_class.endian(arch) }


### PR DESCRIPTION
This adds the little endian and big endian arches for SuperH.
Opening as a draft for now since the Framework side has not been fully tested.

- [ ] Ensure the updated specs pass

 