### PR TITLE
Add support for RISC-V 32bit / RISC-V 64bit / LoongArch 64-bit

### DIFF
--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -26,36 +26,41 @@ module Arch
   ARCH_ANY     = '_any_'
   ARCH_ALL = ARCH_TYPES   =
     [
-      ARCH_X86       = 'x86',
-      ARCH_X86_64    = 'x86_64',
-      ARCH_X64       = 'x64', # To be used for compatability with ARCH_X86_64
-      ARCH_MIPS      = 'mips',
-      ARCH_MIPSLE    = 'mipsle',
-      ARCH_MIPSBE    = 'mipsbe',
-      ARCH_MIPS64    = 'mips64',
-      ARCH_MIPS64LE  = 'mips64le',
-      ARCH_PPC       = 'ppc',
-      ARCH_PPCE500V2 = 'ppce500v2',
-      ARCH_PPC64     = 'ppc64',
-      ARCH_PPC64LE   = 'ppc64le',
-      ARCH_CBEA      = 'cbea',
-      ARCH_CBEA64    = 'cbea64',
-      ARCH_SPARC     = 'sparc',
-      ARCH_SPARC64   = 'sparc64',
-      ARCH_ARMLE     = 'armle',
-      ARCH_ARMBE     = 'armbe',
-      ARCH_AARCH64   = 'aarch64',
-      ARCH_CMD       = 'cmd',
-      ARCH_PHP       = 'php',
-      ARCH_TTY       = 'tty',
-      ARCH_JAVA      = 'java',
-      ARCH_RUBY      = 'ruby',
-      ARCH_DALVIK    = 'dalvik',
-      ARCH_PYTHON    = 'python',
-      ARCH_NODEJS    = 'nodejs',
-      ARCH_FIREFOX   = 'firefox',
-      ARCH_ZARCH     = 'zarch',
-      ARCH_R         = 'r'
+      ARCH_X86         = 'x86',
+      ARCH_X86_64      = 'x86_64',
+      ARCH_X64         = 'x64', # To be used for compatability with ARCH_X86_64
+      ARCH_MIPS        = 'mips',
+      ARCH_MIPSLE      = 'mipsle',
+      ARCH_MIPSBE      = 'mipsbe',
+      ARCH_MIPS64      = 'mips64',
+      ARCH_MIPS64LE    = 'mips64le',
+      ARCH_PPC         = 'ppc',
+      ARCH_PPCE500V2   = 'ppce500v2',
+      ARCH_PPC64       = 'ppc64',
+      ARCH_PPC64LE     = 'ppc64le',
+      ARCH_CBEA        = 'cbea',
+      ARCH_CBEA64      = 'cbea64',
+      ARCH_SPARC       = 'sparc',
+      ARCH_SPARC64     = 'sparc64',
+      ARCH_ARMLE       = 'armle',
+      ARCH_ARMBE       = 'armbe',
+      ARCH_AARCH64     = 'aarch64',
+      ARCH_CMD         = 'cmd',
+      ARCH_PHP         = 'php',
+      ARCH_TTY         = 'tty',
+      ARCH_JAVA        = 'java',
+      ARCH_RUBY        = 'ruby',
+      ARCH_DALVIK      = 'dalvik',
+      ARCH_PYTHON      = 'python',
+      ARCH_NODEJS      = 'nodejs',
+      ARCH_FIREFOX     = 'firefox',
+      ARCH_ZARCH       = 'zarch',
+      ARCH_R           = 'r',
+      ARCH_RISCV32BE   = 'riscv32be',
+      ARCH_RISCV32LE   = 'riscv32le',
+      ARCH_RISCV64BE   = 'riscv64be',
+      ARCH_RISCV64LE   = 'riscv64le',
+      ARCH_LOONGARCH64 = 'loongarch64',
     ]
 
   #
@@ -126,6 +131,16 @@ module Arch
         [addr].pack('Q<')
       when ARCH_ZARCH
         [addr].pack('Q>')
+      when ARCH_RISCV32BE
+        [addr].pack('N')
+      when ARCH_RISCV32LE
+        [addr].pack('V')
+      when ARCH_RISCV64BE
+        [addr].pack('Q>')
+      when ARCH_RISCV64LE
+        [addr].pack('Q<')
+      when ARCH_LOONGARCH64
+        [addr].pack('Q<')
     end
   end
 
@@ -173,6 +188,16 @@ module Arch
         return ENDIAN_LITTLE
       when ARCH_ZARCH
         return ENDIAN_BIG
+      when ARCH_RISCV32BE
+        return ENDIAN_BIG
+      when ARCH_RISCV32LE
+        return ENDIAN_LITTLE
+      when ARCH_RISCV64BE
+        return ENDIAN_BIG
+      when ARCH_RISCV64LE
+        return ENDIAN_LITTLE
+      when ARCH_LOONGARCH64
+        return ENDIAN_LITTLE
     end
 
     return ENDIAN_LITTLE

--- a/spec/lib/rex/arch_spec.rb
+++ b/spec/lib/rex/arch_spec.rb
@@ -166,6 +166,46 @@ RSpec.describe Rex::Arch do
       end
     end
 
+    context "when arch is ARCH_RISCV32BE" do
+      let(:arch) { Rex::Arch::ARCH_RISCV32BE }
+      let(:addr) { 0x41424344 }
+      it "packs addr as 32-bit unsigned, big-endian" do
+        is_expected.to eq("ABCD")
+      end
+    end
+
+    context "when arch is ARCH_RISCV32LE" do
+      let(:arch) { Rex::Arch::ARCH_RISCV32LE }
+      let(:addr) { 0x41424344 }
+      it "packs addr as 32-bit unsigned, little-endian" do
+        is_expected.to eq("DCBA")
+      end
+    end
+
+    context "when arch is ARCH_RISCV64BE" do
+      let(:arch) { Rex::Arch::ARCH_RISCV64BE }
+      let(:addr) { 0x4142434445464748 }
+      it "packs addr as 64-bit unsigned, big-endian" do
+        is_expected.to eq("ABCDEFGH")
+      end
+    end
+
+    context "when arch is ARCH_RISCV64LE" do
+      let(:arch) { Rex::Arch::ARCH_RISCV64LE }
+      let(:addr) { 0x4142434445464748 }
+      it "packs addr as 64-bit unsigned, little-endian" do
+        is_expected.to eq("HGFEDCBA")
+      end
+    end
+
+    context "when arch is ARCH_LOONGARCH64" do
+      let(:arch) { Rex::Arch::ARCH_LOONGARCH64 }
+      let(:addr) { 0x4142434445464748 }
+      it "packs addr as 64-bit unsigned, little-endian" do
+        is_expected.to eq("HGFEDCBA")
+      end
+    end
+
     context "when arch is invalid" do
       let(:arch) { Rex::Arch::ARCH_FIREFOX }
       let(:addr) { 0x41424344 }
@@ -199,7 +239,12 @@ RSpec.describe Rex::Arch do
         Rex::Arch::ARCH_SPARC => Rex::Arch::ENDIAN_BIG,
         Rex::Arch::ARCH_ARMLE => Rex::Arch::ENDIAN_LITTLE,
         Rex::Arch::ARCH_ARMBE => Rex::Arch::ENDIAN_BIG,
-        Rex::Arch::ARCH_AARCH64 => Rex::Arch::ENDIAN_LITTLE
+        Rex::Arch::ARCH_AARCH64 => Rex::Arch::ENDIAN_LITTLE,
+        Rex::Arch::ARCH_RISCV32BE => Rex::Arch::ENDIAN_BIG,
+        Rex::Arch::ARCH_RISCV32LE => Rex::Arch::ENDIAN_LITTLE,
+        Rex::Arch::ARCH_RISCV64BE => Rex::Arch::ENDIAN_BIG,
+        Rex::Arch::ARCH_RISCV64LE => Rex::Arch::ENDIAN_LITTLE,
+        Rex::Arch::ARCH_LOONGARCH64 => Rex::Arch::ENDIAN_LITTLE,
       }
     end
     subject { described_class.endian(arch) }


### PR DESCRIPTION
This PR adds basic support for RISCV and LoongArch by defining the following constants for use within Metasploit Framework and accompanying `rex-*` libraries:

* `RISCV32BE`
* `RISCV32LE`
* `RISCV64BE`
* `RISCV64LE`
* `LOONGARCH64`


# RISC-V

RISC-V is rapidly gaining popularity. The first three [mentions of RISC-V on the Metasploit issue tracker](https://github.com/rapid7/metasploit-framework/issues?q=risc-v) occurred within the past 6 months.


# LoongArch

This PR adds support for LoongArch 64-bit - not 32-bit.

`LOONGARCH64` was chosen as the constant name (rather than `LOONG64`) to differentiate from [Loongson](https://en.wikipedia.org/wiki/Loongson) chips and 32-bit predecessors.

The [Linux kernel documentation](https://lwn.net/Articles/861951/) offers the following:

> LoongArch is a new RISC ISA, which is a bit like MIPS or RISC-V.
> LoongArch includes a reduced 32-bit version (LA32R), a standard 32-bit
> version (LA32S) and a 64-bit version (LA64).

Candidates for future constant names are:

* `LOONGARCH32`
* `LOONGARCH32R`
* `LOONGARCH32S`

I have not been able to emulate a LoongArch 32-bit system (due to limited community interest and limited personal interest).
