### PR TITLE
Add register constants

### DIFF
--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -16,9 +16,20 @@ module Arch
   #
   # Architecture classes
   #
-  require 'rex/arch/x86'
+  require 'rex/arch/aarch64'
+  require 'rex/arch/amd64'
+  require 'rex/arch/arm'
+  require 'rex/arch/loongarch64'
+  require 'rex/arch/mips32'
+  require 'rex/arch/mips64'
+  require 'rex/arch/ppc32'
+  require 'rex/arch/ppc64'
+  require 'rex/arch/riscv32'
+  require 'rex/arch/riscv64'
   require 'rex/arch/sparc'
+  require 'rex/arch/x86'
   require 'rex/arch/zarch'
+
 
   #
   # Architecture constants

--- a/lib/rex/arch/aarch64.rb
+++ b/lib/rex/arch/aarch64.rb
@@ -1,0 +1,60 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # AArch64 64-bit
+    #
+    module AArch64
+      # Register number constants
+      X0  = W0 = 0        # function arg / return value
+      X1  = W1 = 1        # function arg / return value
+      X2  = W2 = 2        # function arg
+      X3  = W3 = 3        # function arg
+      X4  = W4 = 4        # function arg
+      X5  = W5 = 5        # function arg
+      X6  = W6 = 6        # function arg
+      X7  = W7 = 7        # function arg
+      X8  = W8 = 8        # indirect result location (a.k.a. "indirect result" / sometimes "XR")
+      X9  = W9 = 9        # temporary
+      X10 = W10 = 10      # temporary
+      X11 = W11 = 11      # temporary
+      X12 = W12 = 12      # temporary
+      X13 = W13 = 13      # temporary
+      X14 = W14 = 14      # temporary
+      X15 = W15 = 15      # temporary
+      X16 = W16 = 16      # intra-procedure call scratch (IP0)
+      X17 = W17 = 17      # intra-procedure call scratch (IP1)
+      X18 = W18 = 18      # platform register (reserved by OS)
+      X19 = W19 = 19      # callee-saved
+      X20 = W20 = 20      # callee-saved
+      X21 = W21 = 21      # callee-saved
+      X22 = W22 = 22      # callee-saved
+      X23 = W23 = 23      # callee-saved
+      X24 = W24 = 24      # callee-saved
+      X25 = W25 = 25      # callee-saved
+      X26 = W26 = 26      # callee-saved
+      X27 = W27 = 27      # callee-saved
+      X28 = W28 = 28      # callee-saved
+      X29 = W29 = FP = 29 # frame pointer
+      X30 = W30 = LR = 30 # link register (return address)
+      SP  = 31            # stack pointer (shares encoding with XZR/WZR)
+      XZR = WZR = 31      # zero register (reads as 0, writes ignored)
+
+      # @return the number associated with a named register
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 31 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/amd64.rb
+++ b/lib/rex/arch/amd64.rb
@@ -1,0 +1,43 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # AMD64 (x86_64) 64-bit
+    #
+    module AMD64
+      # Register number constants
+      RAX = EAX = AX = AH = AL = 0   # accumulator
+      RBX = EBX = BX = BH = BL = 1   # base
+      RCX = ECX = CX = CH = CL = 2   # counter
+      RDX = EDX = DX = DH = DL = 3   # data
+      RSI = ESI = SI = 4             # source index
+      RDI = EDI = DI = 5             # destination index
+      RBP = EBP = BP = 6             # base pointer
+      RSP = ESP = SP = 7             # stack pointer
+      R8  = R8D = R8W = R8B = 8      # extended register
+      R9  = R9D = R9W = R9B = 9
+      R10 = R10D = R10W = R10B = 10
+      R11 = R11D = R11W = R11B = 11
+      R12 = R12D = R12W = R12B = 12
+      R13 = R13D = R13W = R13B = 13
+      R14 = R14D = R14W = R14B = 14
+      R15 = R15D = R15W = R15B = 15
+
+      # @return the number associated with a named register
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 15 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/arm.rb
+++ b/lib/rex/arch/arm.rb
@@ -1,0 +1,43 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # ARM 32-bit
+    #
+    module ARM
+      # Register number constants
+      R0  = A1 = 0       # function argument / return value
+      R1  = A2 = 1       # function argument
+      R2  = A3 = 2       # function argument
+      R3  = A4 = 3       # function argument
+      R4  = V1 = 4       # variable / callee-saved
+      R5  = V2 = 5       # variable / callee-saved
+      R6  = V3 = 6       # variable / callee-saved
+      R7  = V4 = 7       # variable / callee-saved
+      R8  = V5 = 8       # variable / callee-saved
+      R9  = V6 = SB = 9  # static base / callee-saved
+      R10 = V7 = SL = 10 # stack limit / callee-saved
+      R11 = V8 = FP = 11 # frame pointer
+      R12 = IP = 12      # intra-procedure scratch
+      R13 = SP = 13      # stack pointer
+      R14 = LR = 14      # link register (return address)
+      R15 = PC = 15      # program counter
+
+      # @return the number associated with a named register
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 15 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/loongarch64.rb
+++ b/lib/rex/arch/loongarch64.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # LoongArch64 64-bit
+    #
+    module LoongArch64
+      # Register number constants
+      R0  = ZERO = 0 # constant 0 (hardwired zero)
+      R1  = RA = 1   # return address
+      R2  = SP = 2   # stack pointer
+      R3  = GP = 3   # global pointer
+      R4  = TP = 4   # thread pointer
+      R5  = T0 = 5   # temporary
+      R6  = T1 = 6   # temporary
+      R7  = T2 = 7   # temporary
+      R8  = T3 = 8   # temporary
+      R9  = T4 = 9   # temporary
+      R10 = T5 = 10  # temporary
+      R11 = T6 = 11  # temporary
+      R12 = T7 = 12  # temporary
+      R13 = T8 = 13  # temporary
+      R14 = T9 = 14  # temporary
+      R15 = T10 = 15 # temporary
+      R16 = T11 = 16 # temporary
+      R17 = T12 = 17 # temporary
+      R18 = T13 = 18 # temporary
+      R19 = T14 = 19 # temporary
+      R20 = T15 = 20 # temporary
+      R21 = T16 = 21 # temporary
+      R22 = T17 = 22 # temporary
+      R23 = T18 = 23 # temporary
+      R24 = T19 = 24 # temporary
+      R25 = T20 = 25 # temporary
+      R26 = T21 = 26 # temporary
+      R27 = T22 = 27 # temporary
+      R28 = T23 = 28 # temporary
+      R29 = FP = 29  # frame pointer
+      R30 = S0 = 30  # saved register
+      R31 = S1 = 31  # saved register
+
+      # @return the number associated with a named register.
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 31 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/mips32.rb
+++ b/lib/rex/arch/mips32.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # MIPS 32-bit
+    #
+    module MIPS32
+      # Register number constants
+      R0  = ZERO = 0     # constant 0
+      R1  = AT = 1       # assembler temporary
+      R2  = V0 = 2       # function return value
+      R3  = V1 = 3       # function return value
+      R4  = A0 = 4       # argument
+      R5  = A1 = 5       # argument
+      R6  = A2 = 6       # argument
+      R7  = A3 = 7       # argument
+      R8  = T0 = 8       # temporary
+      R9  = T1 = 9       # temporary
+      R10 = T2 = 10      # temporary
+      R11 = T3 = 11      # temporary
+      R12 = T4 = 12      # temporary
+      R13 = T5 = 13      # temporary
+      R14 = T6 = 14      # temporary
+      R15 = T7 = 15      # temporary
+      R16 = S0 = 16      # saved register
+      R17 = S1 = 17      # saved register
+      R18 = S2 = 18      # saved register
+      R19 = S3 = 19      # saved register
+      R20 = S4 = 20      # saved register
+      R21 = S5 = 21      # saved register
+      R22 = S6 = 22      # saved register
+      R23 = S7 = 23      # saved register
+      R24 = T8 = 24      # temporary
+      R25 = T9 = 25      # temporary
+      R26 = K0 = 26      # reserved for OS
+      R27 = K1 = 27      # reserved for OS
+      R28 = GP = 28      # global pointer
+      R29 = SP = 29      # stack pointer
+      R30 = FP = S8 = 30 # frame pointer / saved
+      R31 = RA = 31      # return address
+
+      # @return the number associated with a named register
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 31 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/mips64.rb
+++ b/lib/rex/arch/mips64.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # MIPS 64-bit
+    #
+    module MIPS64
+      # Register number constants
+      R0  = ZERO = 0     # constant 0
+      R1  = AT = 1       # assembler temporary
+      R2  = V0 = 2       # function return value
+      R3  = V1 = 3       # function return value
+      R4  = A0 = 4       # argument
+      R5  = A1 = 5       # argument
+      R6  = A2 = 6       # argument
+      R7  = A3 = 7       # argument
+      R8  = T0 = 8       # temporary
+      R9  = T1 = 9       # temporary
+      R10 = T2 = 10      # temporary
+      R11 = T3 = 11      # temporary
+      R12 = T4 = 12      # temporary
+      R13 = T5 = 13      # temporary
+      R14 = T6 = 14      # temporary
+      R15 = T7 = 15      # temporary
+      R16 = S0 = 16      # saved register
+      R17 = S1 = 17      # saved register
+      R18 = S2 = 18      # saved register
+      R19 = S3 = 19      # saved register
+      R20 = S4 = 20      # saved register
+      R21 = S5 = 21      # saved register
+      R22 = S6 = 22      # saved register
+      R23 = S7 = 23      # saved register
+      R24 = T8 = 24      # temporary
+      R25 = T9 = 25      # temporary
+      R26 = K0 = 26      # reserved for OS
+      R27 = K1 = 27      # reserved for OS
+      R28 = GP = 28      # global pointer
+      R29 = SP = 29      # stack pointer
+      R30 = FP = S8 = 30 # frame pointer / saved
+      R31 = RA = 31      # return address
+
+      # @return the number associated with a named register
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 31 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/ppc32.rb
+++ b/lib/rex/arch/ppc32.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # PPC 32-bit
+    #
+    module PPC32
+      # Register number constants
+      R0  = 0       # scratch / special
+      R1  = SP = 1  # stack pointer
+      R2  = TOC = 2 # table of contents / global pointer
+      R3  = 3       # function argument / return value
+      R4  = 4       # function argument
+      R5  = 5       # function argument
+      R6  = 6       # function argument
+      R7  = 7       # function argument
+      R8  = 8       # function argument
+      R9  = 9       # function argument
+      R10 = 10      # function argument
+      R11 = 11      # temporary
+      R12 = 12      # temporary
+      R13 = 13      # small data area pointer
+      R14 = 14      # callee-saved
+      R15 = 15      # callee-saved
+      R16 = 16      # callee-saved
+      R17 = 17      # callee-saved
+      R18 = 18      # callee-saved
+      R19 = 19      # callee-saved
+      R20 = 20      # callee-saved
+      R21 = 21      # callee-saved
+      R22 = 22      # callee-saved
+      R23 = 23      # callee-saved
+      R24 = 24      # callee-saved
+      R25 = 25      # callee-saved
+      R26 = 26      # callee-saved
+      R27 = 27      # callee-saved
+      R28 = 28      # callee-saved
+      R29 = 29      # callee-saved
+      R30 = 30      # callee-saved
+      R31 = 31      # callee-saved
+
+      # @return the number associated with a named register
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 31 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/ppc64.rb
+++ b/lib/rex/arch/ppc64.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # PPC 64-bit
+    #
+    module PPC64
+      # Register number constants
+      R0  = 0       # scratch / special
+      R1  = SP = 1  # stack pointer
+      R2  = TOC = 2 # table of contents / global pointer
+      R3  = 3       # function argument / return value
+      R4  = 4       # function argument
+      R5  = 5       # function argument
+      R6  = 6       # function argument
+      R7  = 7       # function argument
+      R8  = 8       # function argument
+      R9  = 9       # function argument
+      R10 = 10      # function argument
+      R11 = 11      # temporary
+      R12 = 12      # temporary
+      R13 = 13      # small data area pointer
+      R14 = 14      # callee-saved
+      R15 = 15      # callee-saved
+      R16 = 16      # callee-saved
+      R17 = 17      # callee-saved
+      R18 = 18      # callee-saved
+      R19 = 19      # callee-saved
+      R20 = 20      # callee-saved
+      R21 = 21      # callee-saved
+      R22 = 22      # callee-saved
+      R23 = 23      # callee-saved
+      R24 = 24      # callee-saved
+      R25 = 25      # callee-saved
+      R26 = 26      # callee-saved
+      R27 = 27      # callee-saved
+      R28 = 28      # callee-saved
+      R29 = 29      # callee-saved
+      R30 = 30      # callee-saved
+      R31 = 31      # callee-saved
+
+      # @return the number associated with a named register
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 31 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/riscv32.rb
+++ b/lib/rex/arch/riscv32.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # RISC-V 32-bit
+    #
+    module RISCV32
+      # Register number constants
+      ZERO = X0 = 0      # constant 0
+      RA   = X1 = 1      # return address
+      SP   = X2 = 2      # stack pointer
+      GP   = X3 = 3      # global pointer
+      TP   = X4 = 4      # thread pointer
+      T0   = X5 = 5      # temporary register 0
+      T1   = X6 = 6      # temporary register 1
+      T2   = X7 = 7      # temporary register 2
+      S0   = FP = X8 = 8 # saved register / frame pointer
+      S1   = X9 = 9      # saved register
+      A0   = X10 = 10    # arg / return value
+      A1   = X11 = 11    # arg / return value
+      A2   = X12 = 12    # arg
+      A3   = X13 = 13    # arg
+      A4   = X14 = 14    # arg
+      A5   = X15 = 15    # arg
+      A6   = X16 = 16    # arg
+      A7   = X17 = 17    # arg
+      S2   = X18 = 18    # saved register
+      S3   = X19 = 19    # saved register
+      S4   = X20 = 20    # saved register
+      S5   = X21 = 21    # saved register
+      S6   = X22 = 22    # saved register
+      S7   = X23 = 23    # saved register
+      S8   = X24 = 24    # saved register
+      S9   = X25 = 25    # saved register
+      S10  = X26 = 26    # saved register
+      S11  = X27 = 27    # saved register
+      T3   = X28 = 28    # temporary register
+      T4   = X29 = 29    # temporary register
+      T5   = X30 = 30    # temporary register
+      T6   = X31 = 31    # temporary register
+
+      # @return the number associated with a named register.
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 31 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/riscv64.rb
+++ b/lib/rex/arch/riscv64.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Arch
+    #
+    # RISC-V 64-bit
+    #
+    module RISCV64
+      # Register number constants
+      ZERO = X0 = 0       # constant 0
+      RA   = X1 = 1       # return address
+      SP   = X2 = 2       # stack pointer
+      GP   = X3 = 3       # global pointer
+      TP   = X4 = 4       # thread pointer
+      T0   = X5 = 5       # temporary register 0
+      T1   = X6 = 6       # temporary register 1
+      T2   = X7 = 7       # temporary register 2
+      S0   = FP = X8 = 8  # saved register / frame pointer
+      S1   = X9 = 9       # saved register
+      A0   = X10 = 10     # arg / return value
+      A1   = X11 = 11     # arg / return value
+      A2   = X12 = 12     # arg
+      A3   = X13 = 13     # arg
+      A4   = X14 = 14     # arg
+      A5   = X15 = 15     # arg
+      A6   = X16 = 16     # arg
+      A7   = X17 = 17     # arg
+      S2   = X18 = 18     # saved register
+      S3   = X19 = 19     # saved register
+      S4   = X20 = 20     # saved register
+      S5   = X21 = 21     # saved register
+      S6   = X22 = 22     # saved register
+      S7   = X23 = 23     # saved register
+      S8   = X24 = 24     # saved register
+      S9   = X25 = 25     # saved register
+      S10  = X26 = 26     # saved register
+      S11  = X27 = 27     # saved register
+      T3   = X28 = 28     # temporary register
+      T4   = X29 = 29     # temporary register
+      T5   = X30 = 30     # temporary register
+      T6   = X31 = 31     # temporary register
+
+      # @return the number associated with a named register.
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
+
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 31 || reg < 0
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/rex/arch/zarch.rb
+++ b/lib/rex/arch/zarch.rb
@@ -1,17 +1,43 @@
 # -*- coding: binary -*-
 
 module Rex
-module Arch
+  module Arch
+    #
+    # z/Arch 64-bit
+    #
+    module ZArch
+      # Register number constants
+      R0  = 0       # general purpose, often scratch
+      R1  = 1       # general purpose, sometimes function arg
+      R2  = 2       # function argument / return value
+      R3  = 3       # function argument
+      R4  = 4       # function argument
+      R5  = 5       # function argument
+      R6  = 6       # function argument
+      R7  = 7       # function argument
+      R8  = 8       # callee-saved / local variable
+      R9  = 9       # callee-saved / local variable
+      R10 = 10      # callee-saved / local variable
+      R11 = 11      # callee-saved / local variable
+      R12 = 12      # callee-saved / local variable
+      R13 = 13      # callee-saved / local variable
+      R14 = LR = 14 # link register (return address)
+      R15 = SP = 15 # stack pointer / base register
 
-#
-# base module for ZARCH creation    8/13/15
-# Author:   BeS Bigendian Smalls
-#
+      # @return the number associated with a named register
+      def self.reg_number(str)
+        const_get(str.upcase)
+      end
 
-module ZARCH
+      # Check if a provided number represents a valid register
+      # @return [Boolean]
+      def self._check_reg(*regs)
+        regs.each do |reg|
+          raise ArgumentError, "Invalid register #{reg}", caller if reg > 15 || reg < 0
+        end
 
-
+        nil
+      end
+    end
+  end
 end
-
-end end
-

--- a/spec/lib/rex/arch/aarch64_spec.rb
+++ b/spec/lib/rex/arch/aarch64_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::AArch64 do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::AArch64::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::AArch64::SP) }
       end
     end
 

--- a/spec/lib/rex/arch/amd64_spec.rb
+++ b/spec/lib/rex/arch/amd64_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::AMD64 do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::AMD64::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::AMD64::SP) }
       end
     end
 

--- a/spec/lib/rex/arch/arm_spec.rb
+++ b/spec/lib/rex/arch/arm_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::ARM do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::ARM::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::ARM::SP) }
       end
     end
 

--- a/spec/lib/rex/arch/loongarch64_spec.rb
+++ b/spec/lib/rex/arch/loongarch64_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::LoongArch64 do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::LoongArch64::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::LoongArch64::SP) }
       end
     end
 

--- a/spec/lib/rex/arch/mips32_spec.rb
+++ b/spec/lib/rex/arch/mips32_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::MIPS32 do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::MIPS32::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::MIPS32::SP) }
       end
     end
 

--- a/spec/lib/rex/arch/mips64_spec.rb
+++ b/spec/lib/rex/arch/mips64_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::MIPS64 do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::MIPS64::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::MIPS64::SP) }
       end
     end
 

--- a/spec/lib/rex/arch/ppc32_spec.rb
+++ b/spec/lib/rex/arch/ppc32_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::PPC32 do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::PPC32::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::PPC32::SP) }
       end
     end
 

--- a/spec/lib/rex/arch/ppc64_spec.rb
+++ b/spec/lib/rex/arch/ppc64_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::PPC64 do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::PPC64::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::PPC64::SP) }
       end
     end
 

--- a/spec/lib/rex/arch/riscv32_spec.rb
+++ b/spec/lib/rex/arch/riscv32_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::RISCV32 do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::RISCV32::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::RISCV32::SP) }
       end
     end
 

--- a/spec/lib/rex/arch/riscv64_spec.rb
+++ b/spec/lib/rex/arch/riscv64_spec.rb
@@ -2,19 +2,19 @@
 require 'spec_helper'
 require 'rex/arch'
 
-RSpec.describe Rex::Arch::ZArch do
+RSpec.describe Rex::Arch::RISCV64 do
   describe ".reg_number" do
     subject { described_class.reg_number(register) }
 
     context "when valid argument" do
       context "in upcase" do
         let(:register) { "SP" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::RISCV64::SP) }
       end
 
       context "in downcase" do
         let(:register) { "sp" }
-        it { is_expected.to eq(Rex::Arch::ZArch::SP) }
+        it { is_expected.to eq(Rex::Arch::RISCV64::SP) }
       end
     end
 


### PR DESCRIPTION
Add register constants for the following architectures:

* aarch64
* amd64
* arm
* loongarch64
* mips32
* mips64
* ppc32
* ppc64
* riscv32
* riscv64
* zarch (replaces the existing empty module)

The constant definitions were generated with Copilot and were lightly reviewed for errors manually.

This allows library users (such as Metasploit) to reference registers by name, for example:

```ruby
# bundle exec irb
irb(main):001> require 'rex/arch'
=> true
irb(main):002> Rex::Arch::RISCV64::SP
=> 2
irb(main):003> 
```

The `reg_number(str)` and `self._check_reg(*regs)` methods defined for each architecture match the existing API used for the X86 architecture.
