### PR TITLE
Add Rex::Arch.from_uname to map uname -m output to ARCH_ constants

### DIFF
--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -219,7 +219,7 @@ module Arch
   # Returns nil if the architecture is not recognized.
   #
   def self.from_uname(uname_arch)
-    case uname_arch.to_s.strip
+    case uname_arch.to_s.downcase.strip
     when 'x86_64', 'x64', 'amd64'
       ARCH_X86_64
     when 'i686', 'i386', 'i486', 'i586'

--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -221,7 +221,7 @@ module Arch
   def self.from_uname(uname_arch)
     case uname_arch.to_s.downcase.strip
     when 'x86_64', 'x64', 'amd64'
-      ARCH_X86_64
+      ARCH_X64
     when 'i686', 'i386', 'i486', 'i586'
       ARCH_X86
     when 'aarch64', 'arm64'

--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -250,9 +250,9 @@ module Arch
       ARCH_SPARC
     when 'sparc64'
       ARCH_SPARC64
-    when /\Ariscv32/
+    when 'riscv32'
       ARCH_RISCV32LE
-    when /\Ariscv64/
+    when 'riscv64'
       ARCH_RISCV64LE
     when 'loongarch64'
       ARCH_LOONGARCH64

--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -220,7 +220,7 @@ module Arch
   #
   def self.from_uname(uname_arch)
     case uname_arch.to_s.strip
-    when 'x86_64', 'amd64'
+    when 'x86_64', 'x64', 'amd64'
       ARCH_X86_64
     when 'i686', 'i386', 'i486', 'i586'
       ARCH_X86

--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -214,5 +214,51 @@ module Arch
     return ENDIAN_LITTLE
   end
 
+#
+  # This routine maps the output of `uname -m` to a Rex architecture constant.
+  # Returns nil if the architecture is not recognized.
+  #
+  def self.from_uname(uname_arch)
+    case uname_arch.to_s.strip
+    when 'x86_64', 'amd64'
+      ARCH_X86_64
+    when 'i686', 'i386', 'i486', 'i586'
+      ARCH_X86
+    when 'aarch64', 'arm64'
+      ARCH_AARCH64
+    when /\Aarmv[0-9].*l/
+      ARCH_ARMLE
+    when /\Aarmv[0-9].*b/
+      ARCH_ARMBE
+    when 'mips'
+      ARCH_MIPSBE
+    when 'mipsel'
+      ARCH_MIPSLE
+    when 'mips64'
+      ARCH_MIPS64
+    when 'mips64el'
+      ARCH_MIPS64LE
+    when 'ppc'
+      ARCH_PPC
+    when 'ppc64'
+      ARCH_PPC64
+    when 'ppc64le'
+      ARCH_PPC64LE
+    when 's390x'
+      ARCH_ZARCH
+    when 'sparc'
+      ARCH_SPARC
+    when 'sparc64'
+      ARCH_SPARC64
+    when /\Ariscv32/
+      ARCH_RISCV32LE
+    when /\Ariscv64/
+      ARCH_RISCV64LE
+    when 'loongarch64'
+      ARCH_LOONGARCH64
+    end
+  end
+
+
 end
 end

--- a/lib/rex/arch.rb
+++ b/lib/rex/arch.rb
@@ -226,9 +226,9 @@ module Arch
       ARCH_X86
     when 'aarch64', 'arm64'
       ARCH_AARCH64
-    when /\Aarmv[0-9].*l/
+    when /\Aarmv[0-9].*l\Z/
       ARCH_ARMLE
-    when /\Aarmv[0-9].*b/
+    when /\Aarmv[0-9].*b\Z/
       ARCH_ARMBE
     when 'mips'
       ARCH_MIPSBE

--- a/spec/lib/rex/arch_spec.rb
+++ b/spec/lib/rex/arch_spec.rb
@@ -284,4 +284,119 @@ RSpec.describe Rex::Arch do
       end
     end
   end
+
+  describe ".from_uname" do
+    subject { described_class.from_uname(uname_arch) }
+
+    context "when uname_arch is x86_64" do
+      let(:uname_arch) { 'x86_64' }
+      it { is_expected.to eq(Rex::Arch::ARCH_X86_64) }
+    end
+
+    context "when uname_arch is amd64" do
+      let(:uname_arch) { 'amd64' }
+      it { is_expected.to eq(Rex::Arch::ARCH_X86_64) }
+    end
+
+    context "when uname_arch is i686" do
+      let(:uname_arch) { 'i686' }
+      it { is_expected.to eq(Rex::Arch::ARCH_X86) }
+    end
+
+    context "when uname_arch is i386" do
+      let(:uname_arch) { 'i386' }
+      it { is_expected.to eq(Rex::Arch::ARCH_X86) }
+    end
+
+    context "when uname_arch is aarch64" do
+      let(:uname_arch) { 'aarch64' }
+      it { is_expected.to eq(Rex::Arch::ARCH_AARCH64) }
+    end
+
+    context "when uname_arch is arm64" do
+      let(:uname_arch) { 'arm64' }
+      it { is_expected.to eq(Rex::Arch::ARCH_AARCH64) }
+    end
+
+    context "when uname_arch is armv7l" do
+      let(:uname_arch) { 'armv7l' }
+      it { is_expected.to eq(Rex::Arch::ARCH_ARMLE) }
+    end
+
+    context "when uname_arch is armv7b" do
+      let(:uname_arch) { 'armv7b' }
+      it { is_expected.to eq(Rex::Arch::ARCH_ARMBE) }
+    end
+
+    context "when uname_arch is mips" do
+      let(:uname_arch) { 'mips' }
+      it { is_expected.to eq(Rex::Arch::ARCH_MIPSBE) }
+    end
+
+    context "when uname_arch is mipsel" do
+      let(:uname_arch) { 'mipsel' }
+      it { is_expected.to eq(Rex::Arch::ARCH_MIPSLE) }
+    end
+
+    context "when uname_arch is mips64" do
+      let(:uname_arch) { 'mips64' }
+      it { is_expected.to eq(Rex::Arch::ARCH_MIPS64) }
+    end
+
+    context "when uname_arch is mips64el" do
+      let(:uname_arch) { 'mips64el' }
+      it { is_expected.to eq(Rex::Arch::ARCH_MIPS64LE) }
+    end
+
+    context "when uname_arch is ppc" do
+      let(:uname_arch) { 'ppc' }
+      it { is_expected.to eq(Rex::Arch::ARCH_PPC) }
+    end
+
+    context "when uname_arch is ppc64" do
+      let(:uname_arch) { 'ppc64' }
+      it { is_expected.to eq(Rex::Arch::ARCH_PPC64) }
+    end
+
+    context "when uname_arch is ppc64le" do
+      let(:uname_arch) { 'ppc64le' }
+      it { is_expected.to eq(Rex::Arch::ARCH_PPC64LE) }
+    end
+
+    context "when uname_arch is s390x" do
+      let(:uname_arch) { 's390x' }
+      it { is_expected.to eq(Rex::Arch::ARCH_ZARCH) }
+    end
+
+    context "when uname_arch is sparc" do
+      let(:uname_arch) { 'sparc' }
+      it { is_expected.to eq(Rex::Arch::ARCH_SPARC) }
+    end
+
+    context "when uname_arch is sparc64" do
+      let(:uname_arch) { 'sparc64' }
+      it { is_expected.to eq(Rex::Arch::ARCH_SPARC64) }
+    end
+
+    context "when uname_arch is riscv64" do
+      let(:uname_arch) { 'riscv64' }
+      it { is_expected.to eq(Rex::Arch::ARCH_RISCV64LE) }
+    end
+
+    context "when uname_arch is loongarch64" do
+      let(:uname_arch) { 'loongarch64' }
+      it { is_expected.to eq(Rex::Arch::ARCH_LOONGARCH64) }
+    end
+
+    context "when uname_arch has leading/trailing whitespace" do
+      let(:uname_arch) { '  x86_64  ' }
+      it { is_expected.to eq(Rex::Arch::ARCH_X86_64) }
+    end
+
+    context "when uname_arch is unrecognized" do
+      let(:uname_arch) { 'unknown_arch' }
+      it { is_expected.to be_nil }
+    end
+  end
+
 end


### PR DESCRIPTION
Adds a new class method from_uname that normalizes the output of 'uname -m' into the corresponding Rex architecture constant.

This is needed by get_os_architecture in metasploit-framework to reliably fingerprint non-meterpreter Linux/BSD shell sessions.

References rapid7/metasploit-framework

#21403